### PR TITLE
Feat battery monitor config

### DIFF
--- a/firmware/config/config.h
+++ b/firmware/config/config.h
@@ -46,14 +46,17 @@
 /* Tasks */
 #define CONFIG_TASK_STARTUP_ENABLED                     1
 #define CONFIG_TASK_WATCHDOG_RESET_ENABLED              1
-#define CONFIG_TASK_HEARTBEAT_ENABLED					1
-#define CONFIG_TASK_SYSTEM_RESET_ENABLED				1
+#define CONFIG_TASK_HEARTBEAT_ENABLED                   1
+#define CONFIG_TASK_SYSTEM_RESET_ENABLED                1
 #define CONFIG_TASK_READ_SENSORS_ENABLED                1
 #define CONFIG_TASK_PARAM_SERVER_ENABLED                1
 #define CONFIG_TASK_MPPT_ALGORITHM_ENABLED              1
 #define CONFIG_TASK_HEATER_CONTROLLER_ENABLED           1
 #define CONFIG_TASK_TIME_CONTROL_ENABLED                1
 #define CONFIG_TASK_DEVICE_RESPONSE_ENABLED             1
+
+/* Tasks Debug Logs*/
+#define CONFIG_TASK_READ_SENSORS_DEBUG_ENABLED          1
 
 /* Devices */
 #define CONFIG_SET_DUMMY_EPS                            0
@@ -71,7 +74,6 @@
 
 /* Drivers */
 #define CONFIG_DRIVERS_DEBUG_ENABLED                    0
-#define CONFIG_DRIVERS_DS277X_ONEWIRE_VERSION           0
 
 #define MAX_BATTERY_CHARGE                              2450    /* [mAh] */
 #define BAT_MONITOR_CHARGE_VALUE                        (uint16_t)(MAX_BATTERY_CHARGE/0.625)    /* 0.625 is a conversion factor for the  battery monitor */

--- a/firmware/devices/battery_monitor/battery_monitor.c
+++ b/firmware/devices/battery_monitor/battery_monitor.c
@@ -24,8 +24,9 @@
  * \brief Battery Monitor device implementation.
  *
  * \author Vinicius Pimenta Bernardo <viniciuspibi@gmail.com>
+ * \author Ramon de Araujo Borba <ramonborba97@gmail.com>
  *
- * \version 0.1.12
+ * \version 0.4.0
  *
  * \date 2021/09/18
  *
@@ -120,7 +121,7 @@ int bm_get_raac_mah(uint16_t *data)
 {
     uint8_t rd_buf[2] = {0};
     if (ds277Xg_read_data(&battery_monitor_config, DS277XG_RAAC_REGISTER_MSB, rd_buf, 2) != 0) {return -1;}
-    *data = (uint16_t)((rd_buf[1] << 8) + rd_buf[0]);
+    *data = (uint16_t)(((rd_buf[0] << 8) + rd_buf[1]) * 1.6);
     return 0;
 }
 
@@ -128,7 +129,7 @@ int bm_get_rsac_mah(uint16_t *data)
 {
     uint8_t rd_buf[2] = {0};
     if (ds277Xg_read_data(&battery_monitor_config, DS277XG_RSAC_REGISTER_MSB, rd_buf, 2) != 0) {return -1;}
-    *data = (uint16_t)((rd_buf[1] << 8) + rd_buf[0]);
+    *data = (uint16_t)(((rd_buf[0] << 8) + rd_buf[1]) * 1.6);
     return 0;
 }
 
@@ -141,5 +142,35 @@ int bm_get_rarc_percent(uint8_t *data)
 int bm_get_rsrc_percent(uint8_t *data)
 {
     if (ds277Xg_read_data(&battery_monitor_config, DS277XG_RSRC_REGISTER, data, 1) != 0) {return -1;}
+    return 0;
+}
+
+int bm_get_acc_current_mah(uint16_t *data)
+{
+    if (ds277Xg_read_accumulated_current_mah(&battery_monitor_config, data) != 0) { return -1; }
+    return 0;
+}
+
+int bm_get_full_capacity_ppm(uint32_t *data)
+{
+    uint8_t rd_buf[2] = {0};
+    if (ds277Xg_read_data(&battery_monitor_config, DS277XG_FULL_REGISTER_MSB, rd_buf, 2) != 0) { return -1; }
+    *data = ((uint32_t)(((rd_buf[0] << 8) + rd_buf[1]) >> 1) * 61);
+    return 0;
+}
+
+int bm_get_active_empty_capacity_ppm(uint32_t *data)
+{
+    uint8_t rd_buf[2] = {0};
+    if (ds277Xg_read_data(&battery_monitor_config, DS277XG_ACTIVE_EMPTY_REGISTER_MSB, rd_buf, 2) != 0) { return -1; }
+    *data = ((uint32_t)(((rd_buf[0] << 8) + rd_buf[1]) >> 1) * 61);
+    return 0;
+}
+
+int bm_get_standby_empty_capacity_ppm(uint32_t *data)
+{
+    uint8_t rd_buf[2] = {0};
+    if (ds277Xg_read_data(&battery_monitor_config, DS277XG_STANDBY_EMPTY_REGISTER_MSB, rd_buf, 2) != 0) { return -1; }
+    *data = ((uint32_t)(((rd_buf[0] << 8) + rd_buf[1]) >> 1) * 61);
     return 0;
 }

--- a/firmware/devices/battery_monitor/battery_monitor.c
+++ b/firmware/devices/battery_monitor/battery_monitor.c
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with EPS 2.0. If not, see <http://www.gnu.org/licenses/>.
+ * along with EPS 2.0. If not, see <http:/\/www.gnu.org/licenses/>.
  *
  */
 
@@ -43,10 +43,27 @@
 #include <drivers/ds277Xg/ds277Xg.h>
 #include <drivers/i2c/i2c.h>
 
+/**
+ * \brief Get the cell one voltage.
+ * 
+ * \param[in,out] voltage Voltage in mV.
+ * \return int The status/error code.
+ */
+static int bm_get_cell_one_voltage(int16_t *voltage);
+
+/**
+ * \brief Get the cell two voltage.
+ * 
+ * \param[in,out] voltage Voltage in mV.
+ * \return int The status/error code.
+ */
+static int bm_get_cell_two_voltage(int16_t *voltage);
+
 ds277Xg_config_t battery_monitor_config = {.port = I2C_PORT_0, .slave_adr = DS2777G_DEFAULT_SLAVE_ADDRESS};
 
-int battery_monitor_init()
+int battery_monitor_init(void)
 {
+    int err = 0;
     sys_log_print_event_from_module(SYS_LOG_INFO, BATTERY_MONITOR_MODULE_NAME, "Initializing Battery Monitor device.");
     sys_log_new_line();
 
@@ -55,118 +72,134 @@ int battery_monitor_init()
        sys_log_print_event_from_module(SYS_LOG_ERROR, BATTERY_MONITOR_MODULE_NAME, "Error initializing Battery Monitor device!");
        sys_log_new_line();
 
-       return -1;
+       err += -1;
     }
 
-    return 0;
+    return err;
 }
 
 int bm_get_cell_one_voltage(int16_t *voltage)
 {
-    if (ds277Xg_read_voltage_mv(&battery_monitor_config, voltage, 1) != 0) {return -1;}
-    return 0;
+    int err = 0;
+    if (ds277Xg_read_voltage_mv(&battery_monitor_config, voltage, 1) != 0) {err += -1;}
+    return err;
 }
 
 int bm_get_cell_two_voltage(int16_t *voltage)
 {
-    if (ds277Xg_read_voltage_mv(&battery_monitor_config, voltage, 2) != 0) {return -1;}
-    return 0;
+    int err = 0;
+    if (ds277Xg_read_voltage_mv(&battery_monitor_config, voltage, 2) != 0) {err += -1;}
+    return err;
 }
 
 int bm_get_voltage(uint16_t *voltage)
 {
+    int err = 0;
     int16_t buf = 0;
-    if (bm_get_cell_one_voltage(&buf) != 0) {return -1;}
+    if (bm_get_cell_one_voltage(&buf) != 0) {err += -1;}
     *voltage = buf;
-    if (bm_get_cell_two_voltage(&buf) != 0) {return -1;}
+    if (bm_get_cell_two_voltage(&buf) != 0) {err += -1;}
     *voltage += buf;
-    return 0;
+    return err;
 }
 
 int bm_get_temperature_kelvin(uint16_t *temp)
 {
-    if (ds277Xg_read_temperature_kelvin(&battery_monitor_config, temp) != 0) {return -1;}
-    return 0;
+    int err = 0;
+    if (ds277Xg_read_temperature_kelvin(&battery_monitor_config, temp) != 0) {err += -1;}
+    return err;
 }
 
 int bm_get_instantaneous_current(int16_t *current)
 {
-    if (ds277Xg_read_current_ma(&battery_monitor_config, current, false) != 0) {return -1;}
-    return 0;
+    int err = 0;
+    if (ds277Xg_read_current_ma(&battery_monitor_config, current, false) != 0) {err += -1;}
+    return err;
 }
 
 int bm_get_average_current(int16_t *current)
 {
-    if (ds277Xg_read_current_ma(&battery_monitor_config, current, true) != 0) {return -1;}
-    return 0;
+    int err = 0; 
+    if (ds277Xg_read_current_ma(&battery_monitor_config, current, true) != 0) {err += -1;}
+    return err;
 }
 
 int bm_get_status_register_data(uint8_t *data)
 {
-    if (ds277Xg_read_data(&battery_monitor_config, DS277XG_STATUS_REGISTER, data, 1) != 0) {return -1;}
-    return 0;
+    int err = 0;
+    if (ds277Xg_read_data(&battery_monitor_config, DS277XG_STATUS_REGISTER, data, 1) != 0) {err += -1;}
+    return err;
 }
 
 int bm_get_protection_register_data(uint8_t *data)
 {
-    if (ds277Xg_read_data(&battery_monitor_config, DS277XG_PROTECTION_REGISTER, data, 1) != 0) {return -1;}
-    return 0;
+    int err = 0;
+    if (ds277Xg_read_data(&battery_monitor_config, DS277XG_PROTECTION_REGISTER, data, 1) != 0) {err += -1;}
+    return err;
 }
 
 int bm_get_raac_mah(uint16_t *data)
 {
+    int err = 0;
     uint8_t rd_buf[2] = {0};
-    if (ds277Xg_read_data(&battery_monitor_config, DS277XG_RAAC_REGISTER_MSB, rd_buf, 2) != 0) {return -1;}
+    if (ds277Xg_read_data(&battery_monitor_config, DS277XG_RAAC_REGISTER_MSB, rd_buf, 2) != 0) {err += -1;}
     *data = (uint16_t)(((rd_buf[0] << 8) + rd_buf[1]) * 1.6);
-    return 0;
+    return err;
 }
 
 int bm_get_rsac_mah(uint16_t *data)
 {
+    int err = 0;
     uint8_t rd_buf[2] = {0};
-    if (ds277Xg_read_data(&battery_monitor_config, DS277XG_RSAC_REGISTER_MSB, rd_buf, 2) != 0) {return -1;}
+    if (ds277Xg_read_data(&battery_monitor_config, DS277XG_RSAC_REGISTER_MSB, rd_buf, 2) != 0) {err += -1;}
     *data = (uint16_t)(((rd_buf[0] << 8) + rd_buf[1]) * 1.6);
-    return 0;
+    return err;
 }
 
 int bm_get_rarc_percent(uint8_t *data)
 {
-    if (ds277Xg_read_data(&battery_monitor_config, DS277XG_RARC_REGISTER, data, 1) != 0) {return -1;}
-    return 0;
+    int err = 0;
+    if (ds277Xg_read_data(&battery_monitor_config, DS277XG_RARC_REGISTER, data, 1) != 0) {err += -1;}
+    return err;
 }
 
 int bm_get_rsrc_percent(uint8_t *data)
 {
-    if (ds277Xg_read_data(&battery_monitor_config, DS277XG_RSRC_REGISTER, data, 1) != 0) {return -1;}
-    return 0;
+    int err = 0;
+    if (ds277Xg_read_data(&battery_monitor_config, DS277XG_RSRC_REGISTER, data, 1) != 0) {err += -1;}
+    return err;
 }
 
 int bm_get_acc_current_mah(uint16_t *data)
 {
-    if (ds277Xg_read_accumulated_current_mah(&battery_monitor_config, data) != 0) { return -1; }
-    return 0;
+    int err = 0;
+    if (ds277Xg_read_accumulated_current_mah(&battery_monitor_config, data) != 0) { err += -1; }
+    return err;
 }
 
 int bm_get_full_capacity_ppm(uint32_t *data)
 {
+    int err = 0;
     uint8_t rd_buf[2] = {0};
-    if (ds277Xg_read_data(&battery_monitor_config, DS277XG_FULL_REGISTER_MSB, rd_buf, 2) != 0) { return -1; }
-    *data = ((uint32_t)(((rd_buf[0] << 8) + rd_buf[1]) >> 1) * 61);
-    return 0;
+    if (ds277Xg_read_data(&battery_monitor_config, DS277XG_FULL_REGISTER_MSB, rd_buf, 2) != 0) { err += -1; }
+    *data = ((uint32_t)(((rd_buf[0] << 8) + rd_buf[1]) >> 1) * 61U);
+    return err;
 }
 
 int bm_get_active_empty_capacity_ppm(uint32_t *data)
 {
+    int err = 0;
     uint8_t rd_buf[2] = {0};
-    if (ds277Xg_read_data(&battery_monitor_config, DS277XG_ACTIVE_EMPTY_REGISTER_MSB, rd_buf, 2) != 0) { return -1; }
-    *data = ((uint32_t)(((rd_buf[0] << 8) + rd_buf[1]) >> 1) * 61);
-    return 0;
+    if (ds277Xg_read_data(&battery_monitor_config, DS277XG_ACTIVE_EMPTY_REGISTER_MSB, rd_buf, 2) != 0) { err += -1; }
+    *data = ((uint32_t)(((rd_buf[0] << 8) + rd_buf[1]) >> 1) * 61U);
+    return err;
 }
 
 int bm_get_standby_empty_capacity_ppm(uint32_t *data)
 {
+    int err = 0;
     uint8_t rd_buf[2] = {0};
-    if (ds277Xg_read_data(&battery_monitor_config, DS277XG_STANDBY_EMPTY_REGISTER_MSB, rd_buf, 2) != 0) { return -1; }
-    *data = ((uint32_t)(((rd_buf[0] << 8) + rd_buf[1]) >> 1) * 61);
-    return 0;
+    if (ds277Xg_read_data(&battery_monitor_config, DS277XG_STANDBY_EMPTY_REGISTER_MSB, rd_buf, 2) != 0) { err += -1; }
+    *data = ((uint32_t)(((rd_buf[0] << 8) + rd_buf[1]) >> 1) * 61U);
+    return err;
 }

--- a/firmware/devices/battery_monitor/battery_monitor.c
+++ b/firmware/devices/battery_monitor/battery_monitor.c
@@ -43,11 +43,7 @@
 #include <drivers/ds277Xg/ds277Xg.h>
 #include <drivers/i2c/i2c.h>
 
-#if defined(CONFIG_DRIVERS_DS277X_ONEWIRE_VERSION) && (CONFIG_DRIVERS_DS277X_ONEWIRE_VERSION == 1)
-ds277Xg_config_t battery_monitor_config = {.port = GPIO_PIN_69};
-#else
 ds277Xg_config_t battery_monitor_config = {.port = I2C_PORT_0, .slave_adr = DS2777G_DEFAULT_SLAVE_ADDRESS};
-#endif
 
 int battery_monitor_init()
 {

--- a/firmware/devices/battery_monitor/battery_monitor.h
+++ b/firmware/devices/battery_monitor/battery_monitor.h
@@ -51,23 +51,7 @@ extern ds277Xg_config_t battery_monitor_config;
  * 
  * \return int The status/error code.
  */
-int battery_monitor_init();
-
-/**
- * \brief Get the cell one voltage.
- * 
- * \param[in,out] voltage Voltage in mV.
- * \return int The status/error code.
- */
-int bm_get_cell_one_voltage(int16_t *voltage);
-
-/**
- * \brief Get the cell two voltage.
- * 
- * \param[in,out] voltage Voltage in mV.
- * \return int The status/error code.
- */
-int bm_get_cell_two_voltage(int16_t *voltage);
+int battery_monitor_init(void);
 
 /**
  * \brief Get the batteries voltage in mV.

--- a/firmware/devices/battery_monitor/battery_monitor.h
+++ b/firmware/devices/battery_monitor/battery_monitor.h
@@ -24,8 +24,9 @@
  * \brief Battery Monitor device definition.
  *
  * \author Vinicius Pimenta Bernardo <viniciuspibi@gmail.com>
+ * \author Ramon de Araujo Borba <ramonborba97@gmail.com>
  *
- * \version 0.1.12
+ * \version 0.4.0
  *
  * \date 2021/09/18
  *
@@ -147,6 +148,38 @@ int bm_get_rarc_percent(uint8_t *data);
  * \return int The status/error code.
  */
 int bm_get_rsrc_percent(uint8_t *data);
+
+/**
+ * \brief Get the battery monitor accumulated current in mAh.
+ * 
+ * \param[in,out] data Register data. 
+ * \return int The status/error code.
+ */
+int bm_get_acc_current_mah(uint16_t *data);
+
+/**
+ * \brief Get the battery monitor full capacity result register in ppm.
+ * 
+ * \param[in,out] data Register data. 
+ * \return int The status/error code.
+ */
+int bm_get_full_capacity_ppm(uint32_t *data);
+
+/**
+ * \brief Get the battery monitor active empty capacity result register in ppm.
+ * 
+ * \param[in,out] data Register data. 
+ * \return int The status/error code.
+ */
+int bm_get_active_empty_capacity_ppm(uint32_t *data);
+
+/**
+ * \brief Get the battery monitor standby empty capacity result register in ppm.
+ * 
+ * \param[in,out] data Register data. 
+ * \return int The status/error code.
+ */
+int bm_get_standby_empty_capacity_ppm(uint32_t *data);
 
 #endif /* BATTERY_MONITOR_H_ */
 

--- a/firmware/drivers/ds277Xg/ds277Xg.c
+++ b/firmware/drivers/ds277Xg/ds277Xg.c
@@ -570,28 +570,14 @@ int ds277Xg_read_cycle_counter(ds277Xg_config_t *config, uint16_t *cycles)
 
 int ds277Xg_write_data(ds277Xg_config_t *config, uint8_t *data, const uint16_t len)
 {
-#if defined(CONFIG_DRIVERS_DS277X_ONEWIRE_VERSION) && (CONFIG_DRIVERS_DS277X_ONEWIRE_VERSION == 1)
-    if(onewire_reset(config->port) == 0) {return -1;}
-    if(onewire_write_byte(config->port, data, len) == -1) {return -1;}
-    return 0;
-#else
     return i2c_write(config->port, config->slave_adr, data, len);
-#endif
 }
 
 int ds277Xg_read_data(ds277Xg_config_t *config, uint8_t target_reg, uint8_t *data, uint16_t len)
 {
-#if defined(CONFIG_DRIVERS_DS277X_ONEWIRE_VERSION) && (CONFIG_DRIVERS_DS277X_ONEWIRE_VERSION == 1)
-    uint8_t read_command[3] = {DS2775G_SKIP_ADDRESS, DS2775G_READ_DATA, target_reg};
-    if(ds277Xg_write_data(config, read_command, 0x3) == -1) {return -1;}
-    if(onewire_read_byte(config->port, data, len) == -1) {return -1;}
-    return 0;
-#else
     uint8_t reg[1] = {target_reg};
-
     if (i2c_write(config->port, config->slave_adr, reg, 1) != 0) {return -1;}
     return i2c_read(config->port, config->slave_adr, data, len);
-#endif
 }
 
 /** \} End of ds277Xg group */

--- a/firmware/drivers/ds277Xg/ds277Xg.c
+++ b/firmware/drivers/ds277Xg/ds277Xg.c
@@ -40,6 +40,197 @@
 
 #include "ds277Xg.h"
 
+
+/**
+ * @brief Set battery configuration to initial state.
+ * 
+ * Run this function ONCE when a new battery is connected to reset
+ * accumulated current and aging estimation to initial values.
+ * 
+ * @param config DS277XG configuration parameters.
+ * @return int The status/error code.
+ */
+static int ds277Xg_set_battery_to_initial_state(ds277Xg_config_t *config);
+
+/**
+ * \brief Set charge enable bit in protection register.
+ * 
+ * \param[in] config DS277XG configuration parameters.
+ * \return int The status/error code.
+ */
+static int ds277Xg_enable_charge(ds277Xg_config_t *config);
+
+/**
+ * \brief Set discharge enable bit in protection register.
+ * 
+ * \param[in] config DS277XG configuration parameters.
+ * \return int The status/error code.
+ */
+static int ds277Xg_enable_discharge(ds277Xg_config_t *config);
+
+/**
+ * \brief Reset charge enable bit in protection register.
+ * 
+ * \param[in] config DS277XG configuration parameters.
+ * \return int The status/error code.
+ */
+static int ds277Xg_disable_charge(ds277Xg_config_t *config);
+
+/**
+ * \brief Reset discharge enable bit in protection register.
+ * 
+ * \param[in] config DS277XG configuration parameters.
+ * \return int The status/error code.
+ */
+static int ds277Xg_disable_discharge(ds277Xg_config_t *config);
+
+/**
+ * \brief Get the raw voltage in two's complement form from the DS277XG.
+ * 
+ * \param[in] config DS277XG configuration parameters.
+ * \param[in,out] voltage_raw The raw voltage value.
+ * \param[in] battery_select Must be either 1 or 2.
+ * \return int The status/error code.
+ */
+static int ds277Xg_read_voltage_raw(ds277Xg_config_t *config, int16_t *voltage_raw, uint8_t battery_select);
+
+/**
+ * \brief Convert from raw data to mV.
+ * 
+ * Resolution: 4.8828mV. Goes from -5000mV to 4995.1mV
+ * Sign | 2^9 | 2^8 | 2^7 | 2^6 | 2^5 | 2^4 | 2^3 | 2^2 | 2^1 | 2^0 | X | X | X | X | X
+ *                       MSB                      |                    LSB              
+ * 
+ * \param[in] raw The raw voltage value.
+ * \return float Converted voltage in mV.
+ */
+static int16_t ds277Xg_voltage_raw_to_mv(int16_t raw);
+
+/**
+ * \brief Get the raw temperature in two's complement form from the DS277XG.
+ * 
+ * \param[in] config DS277XG configuration parameters.
+ * \param[in,out] temp_raw The raw temperature value.
+ * \return int The status/error code.
+ */
+static int ds277Xg_read_temperature_raw(ds277Xg_config_t *config, int16_t *temp_raw);
+
+/**
+ * \brief Convert from raw data to kelvin.
+ * 
+ * Resolution: 0.125 degrees kelvin.
+ * Sign | 2^9 | 2^8 | 2^7 | 2^6 | 2^5 | 2^4 | 2^3 | 2^2 | 2^1 | 2^0 | X | X | X | X | X
+ *                       MSB                      |                    LSB              
+ * 
+ * \param[in] raw The raw temperature value.
+ * \return uint16_t Converted temperature in kelvin.
+ */
+static uint16_t ds277Xg_temperature_raw_to_kelvin(int16_t raw);
+
+/**
+ * \brief Get the raw current in two's complement form from the DS277XG.
+ * 
+ * \param[in] config DS277XG configuration parameters.
+ * \param[in,out] current_raw The raw current value.
+ * \param[in] read_average Whether to read the last current raw value [false] or a mean of the last eight values [true].
+ * \return int The status/error code.
+ */
+static int ds277Xg_read_current_raw(ds277Xg_config_t *config, int16_t *current_raw, bool read_average);
+
+/**
+ * \brief Convert from raw data to mA.
+ * 
+ * Resolution: 1.5625uV/R_sense. Goes from -51.2mV/R_sense to 51.2mV/R_sense.
+ * 
+ * \param[in] raw The raw current value.
+ * \return int16_t Converted current in mA.
+ */
+static int16_t ds277Xg_current_raw_to_ma(int16_t raw);
+
+/**
+ * \brief Write the raw accumulated current in two's complement form to the DS277XG.
+ * 
+ * \param[in] config DS277XG configuration parameters.
+ * \param[in] acc_current_raw The raw accumulated current value to write.
+ * \return int The status/error code.
+ */
+static int ds277Xg_write_accumulated_current_raw(ds277Xg_config_t *config, uint16_t acc_current_raw);
+
+/**
+ * \brief Convert from mAh data to raw.
+ * 
+ * \param[in] mah The mAh accumulated current value.
+ * \return uint16_t Converted raw accumulated current value.
+ */
+static uint16_t ds277Xg_accumulated_current_mah_to_raw(uint16_t mah);
+
+/**
+ * \brief Write the accumulated current in mAh to the DS277XG.
+ * 
+ * \param[in] config DS277XG configuration parameters.
+ * \param[in] acc_current_mah Accumulated current in mAh.
+ * \return int The status/error code.
+ */
+static int ds277Xg_write_accumulated_current_mah(ds277Xg_config_t *config, uint16_t acc_current_mah);
+
+/**
+ * \brief Write the battery max charge value in mAh to the DS277XG.
+ * 
+ * \param[in] config DS277XG configuration parameters.
+ * \return int The status/error code.
+ */
+static int ds277Xg_write_accumulated_current_max_value(ds277Xg_config_t *config);
+
+/**
+ * \brief Get the raw accumulated current in two's complement form from the DS277XG.
+ * 
+ * \param[in] config DS277XG configuration parameters.
+ * \param[in,out] acc_current_raw The raw accumulated current value.
+ * \return int The status/error code.
+ */
+static int ds277Xg_read_accumulated_current_raw(ds277Xg_config_t *config, uint16_t *acc_current_raw);
+
+/**
+ * \brief Convert from raw data to mAh.
+ * 
+ * Resolution: 6.25uVh/R_sense. Goes from 0 to 409.6mVh/R_sense.
+ * 
+ * \param[in] raw The raw accumulated current value.
+ * \return uint16_t Converted accumulated current in mAh.
+ */
+static uint16_t ds277Xg_accumulated_current_raw_to_mah(uint16_t raw);
+
+/**
+ * \brief Write number of cycles to the DS277XG.
+ * 
+ * \param[in] config DS277XG configuration parameters.
+ * \param[in] cycles The number of cycles to write. Goes from 0 to 510.
+ * \return int The status/error code.
+ */
+static int ds277Xg_write_cycle_counter(ds277Xg_config_t *config, uint16_t cycles);
+
+/**
+ * \brief Read number of cycles from the DS277XG.
+ * 
+ * \param[in] config DS277XG configuration parameters.
+ * \param[in,out] cycles The number of cycles to write. Goes from 0 to 510.
+ * \return int The status/error code.
+ */
+static int ds277Xg_read_cycle_counter(ds277Xg_config_t *config, uint16_t *cycles);
+
+/**
+ * \brief Write-Data Protocol
+ * 
+ * Start SAddr MAddr Data0 Data1 ... DataN Stop
+ * 
+ * \param[in] config DS277XG configuration parameters.
+ * \param[in] data Data to write. First byte must be target register address.
+ * \param[in] len Length of the data to write, including target register.
+ * \return int The status/error code.
+ */
+static int ds277Xg_write_data(ds277Xg_config_t *config, uint8_t *data, uint16_t len);
+
+
 int ds277Xg_init(ds277Xg_config_t *config)
 {
     /* I2C port initialization. */
@@ -357,7 +548,7 @@ int ds277Xg_read_accumulated_current_mah(ds277Xg_config_t *config, uint16_t *acc
         return -1;
     }
 
-    *acc_current_mah = ds277Xg_current_raw_to_ma(acc_current_raw);
+    *acc_current_mah = ds277Xg_accumulated_current_raw_to_mah(acc_current_raw);
     return 0;
 }
 

--- a/firmware/drivers/ds277Xg/ds277Xg.h
+++ b/firmware/drivers/ds277Xg/ds277Xg.h
@@ -43,11 +43,7 @@
 
 #include <config/config.h>
 
-#if defined(CONFIG_DRIVERS_DS277X_ONEWIRE_VERSION) && (CONFIG_DRIVERS_DS277X_ONEWIRE_VERSION == 1)
-#include <drivers/onewire/onewire.h>
-#else
 #include <drivers/i2c/i2c.h>
-#endif
 
 #define DS277XG_MODULE_NAME "DS277X"
 
@@ -268,12 +264,8 @@
 
 typedef struct
 {
-#if defined(CONFIG_DRIVERS_DS277X_ONEWIRE_VERSION) && (CONFIG_DRIVERS_DS277X_ONEWIRE_VERSION == 1)
-    onewire_port_t port;
-#else
     i2c_port_t  port;
     i2c_slave_adr_t slave_adr;
-#endif
 } ds277Xg_config_t;
 
 /**

--- a/firmware/drivers/ds277Xg/ds277Xg.h
+++ b/firmware/drivers/ds277Xg/ds277Xg.h
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  * 
  * You should have received a copy of the GNU General Public License
- * along with EPS 2.0. If not, see <http://www.gnu.org/licenses/>.
+ * along with EPS 2.0. If not, see <http:/\/www.gnu.org/licenses/>.
  * 
  */
 
@@ -53,9 +53,9 @@
 
 /**
  * References
- * https://datasheets.maximintegrated.com/en/ds/DS2775-DS2778.pdf
- * https://www.maximintegrated.com/en/design/technical-documents/app-notes/3/3584.html
- * https://www.maximintegrated.com/en/design/technical-documents/app-notes/1/131.html
+ * https:/\/datasheets.maximintegrated.com/en/ds/DS2775-DS2778.pdf
+ * https:/\/www.maximintegrated.com/en/design/technical-documents/app-notes/3/3584.html
+ * https:/\/www.maximintegrated.com/en/design/technical-documents/app-notes/1/131.html
  */
 
 /**
@@ -285,71 +285,6 @@ typedef struct
 int ds277Xg_init(ds277Xg_config_t *config);
 
 /**
- * @brief Set battery configuration to initial state.
- * 
- * Run this function ONCE when a new battery is connected to reset
- * accumulated current and aging estimation to initial values.
- * 
- * @param config DS277XG configuration parameters.
- * @return int The status/error code.
- */
-int ds277Xg_set_battery_to_initial_state(ds277Xg_config_t *config);
-
-/**
- * \brief Set charge enable bit in protection register.
- * 
- * \param[in] config DS277XG configuration parameters.
- * \return int The status/error code.
- */
-int ds277Xg_enable_charge(ds277Xg_config_t *config);
-
-/**
- * \brief Set discharge enable bit in protection register.
- * 
- * \param[in] config DS277XG configuration parameters.
- * \return int The status/error code.
- */
-int ds277Xg_enable_discharge(ds277Xg_config_t *config);
-
-/**
- * \brief Reset charge enable bit in protection register.
- * 
- * \param[in] config DS277XG configuration parameters.
- * \return int The status/error code.
- */
-int ds277Xg_disable_charge(ds277Xg_config_t *config);
-
-/**
- * \brief Reset discharge enable bit in protection register.
- * 
- * \param[in] config DS277XG configuration parameters.
- * \return int The status/error code.
- */
-int ds277Xg_disable_discharge(ds277Xg_config_t *config);
-
-/**
- * \brief Get the raw voltage in two's complement form from the DS277XG.
- * 
- * \param[in] config DS277XG configuration parameters.
- * \param[in,out] voltage_raw The raw voltage value.
- * \param[in] battery_select Must be either 1 or 2.
- * \return int The status/error code.
- */
-int ds277Xg_read_voltage_raw(ds277Xg_config_t *config, int16_t *voltage_raw, uint8_t battery_select);
-
-/**
- * \brief Convert from raw data to mV.
- * 
- * Resolution: 4.8828mV. Goes from -5000mV to 4995.1mV
- * Sign | 2^9 | 2^8 | 2^7 | 2^6 | 2^5 | 2^4 | 2^3 | 2^2 | 2^1 | 2^0 | X | X | X | X | X
- *                       MSB                      |                    LSB              
- * 
- * \param[in] raw The raw voltage value.
- * \return float Converted voltage in mV.
- */
-int16_t ds277Xg_voltage_raw_to_mv(int16_t raw);
-
-/**
  * \brief Get the voltage in mV from one of the batteries connected to the DS277XG.
  * 
  * \param[in] config DS277XG configuration parameters.
@@ -360,27 +295,6 @@ int16_t ds277Xg_voltage_raw_to_mv(int16_t raw);
 int ds277Xg_read_voltage_mv(ds277Xg_config_t *config, int16_t *voltage_mv, uint8_t battery_select);
 
 /**
- * \brief Get the raw temperature in two's complement form from the DS277XG.
- * 
- * \param[in] config DS277XG configuration parameters.
- * \param[in,out] temp_raw The raw temperature value.
- * \return int The status/error code.
- */
-int ds277Xg_read_temperature_raw(ds277Xg_config_t *config, int16_t *temp_raw);
-
-/**
- * \brief Convert from raw data to kelvin.
- * 
- * Resolution: 0.125 degrees kelvin.
- * Sign | 2^9 | 2^8 | 2^7 | 2^6 | 2^5 | 2^4 | 2^3 | 2^2 | 2^1 | 2^0 | X | X | X | X | X
- *                       MSB                      |                    LSB              
- * 
- * \param[in] raw The raw temperature value.
- * \return uint16_t Converted temperature in kelvin.
- */
-uint16_t ds277Xg_temperature_raw_to_kelvin(int16_t raw);
-
-/**
  * \brief Get the temperature in kelvin from the DS277XG.
  * 
  * \param[in] config DS277XG configuration parameters.
@@ -388,26 +302,6 @@ uint16_t ds277Xg_temperature_raw_to_kelvin(int16_t raw);
  * \return int The status/error code.
  */
 int ds277Xg_read_temperature_kelvin(ds277Xg_config_t *config, uint16_t *temp_kelvin);
-
-/**
- * \brief Get the raw current in two's complement form from the DS277XG.
- * 
- * \param[in] config DS277XG configuration parameters.
- * \param[in,out] current_raw The raw current value.
- * \param[in] read_average Whether to read the last current raw value [false] or a mean of the last eight values [true].
- * \return int The status/error code.
- */
-int ds277Xg_read_current_raw(ds277Xg_config_t *config, int16_t *current_raw, bool read_average);
-
-/**
- * \brief Convert from raw data to mA.
- * 
- * Resolution: 1.5625uV/R_sense. Goes from -51.2mV/R_sense to 51.2mV/R_sense.
- * 
- * \param[in] raw The raw current value.
- * \return int16_t Converted current in mA.
- */
-int16_t ds277Xg_current_raw_to_ma(int16_t raw);
 
 /**
  * \brief Get the current in mA from the DS277XG (instantaneous or average from last eight).
@@ -420,59 +314,6 @@ int16_t ds277Xg_current_raw_to_ma(int16_t raw);
 int ds277Xg_read_current_ma(ds277Xg_config_t *config, int16_t *current_ma, bool read_average);
 
 /**
- * \brief Write the raw accumulated current in two's complement form to the DS277XG.
- * 
- * \param[in] config DS277XG configuration parameters.
- * \param[in] acc_current_raw The raw accumulated current value to write.
- * \return int The status/error code.
- */
-int ds277Xg_write_accumulated_current_raw(ds277Xg_config_t *config, uint16_t acc_current_raw);
-
-/**
- * \brief Convert from mAh data to raw.
- * 
- * \param[in] mah The mAh accumulated current value.
- * \return uint16_t Converted raw accumulated current value.
- */
-uint16_t ds277Xg_accumulated_current_mah_to_raw(uint16_t mah);
-
-/**
- * \brief Write the accumulated current in mAh to the DS277XG.
- * 
- * \param[in] config DS277XG configuration parameters.
- * \param[in] acc_current_mah Accumulated current in mAh.
- * \return int The status/error code.
- */
-int ds277Xg_write_accumulated_current_mah(ds277Xg_config_t *config, uint16_t acc_current_mah);
-
-/**
- * \brief Write the battery max charge value in mAh to the DS277XG.
- * 
- * \param[in] config DS277XG configuration parameters.
- * \return int The status/error code.
- */
-int ds277Xg_write_accumulated_current_max_value(ds277Xg_config_t *config);
-
-/**
- * \brief Get the raw accumulated current in two's complement form from the DS277XG.
- * 
- * \param[in] config DS277XG configuration parameters.
- * \param[in,out] acc_current_raw The raw accumulated current value.
- * \return int The status/error code.
- */
-int ds277Xg_read_accumulated_current_raw(ds277Xg_config_t *config, uint16_t *acc_current_raw);
-
-/**
- * \brief Convert from raw data to mAh.
- * 
- * Resolution: 6.25uVh/R_sense. Goes from 0 to 409.6mVh/R_sense.
- * 
- * \param[in] raw The raw accumulated current value.
- * \return uint16_t Converted accumulated current in mAh.
- */
-uint16_t ds277Xg_accumulated_current_raw_to_mah(uint16_t raw);
-
-/**
  * \brief Get the accumulated current in mAh from the DS277XG.
  * 
  * \param[in] config DS277XG configuration parameters.
@@ -480,36 +321,6 @@ uint16_t ds277Xg_accumulated_current_raw_to_mah(uint16_t raw);
  * \return int The status/error code.
  */
 int ds277Xg_read_accumulated_current_mah(ds277Xg_config_t *config, uint16_t *acc_current_mah);
-
-/**
- * \brief Write number of cycles to the DS277XG.
- * 
- * \param[in] config DS277XG configuration parameters.
- * \param[in] cycles The number of cycles to write. Goes from 0 to 510.
- * \return int The status/error code.
- */
-int ds277Xg_write_cycle_counter(ds277Xg_config_t *config, uint16_t cycles);
-
-/**
- * \brief Read number of cycles from the DS277XG.
- * 
- * \param[in] config DS277XG configuration parameters.
- * \param[in,out] cycles The number of cycles to write. Goes from 0 to 510.
- * \return int The status/error code.
- */
-int ds277Xg_read_cycle_counter(ds277Xg_config_t *config, uint16_t *cycles);
-
-/**
- * \brief Write-Data Protocol
- * 
- * Start SAddr MAddr Data0 Data1 ... DataN Stop
- * 
- * \param[in] config DS277XG configuration parameters.
- * \param[in] data Data to write. First byte must be target register address.
- * \param[in] len Length of the data to write, including target register.
- * \return int The status/error code.
- */
-int ds277Xg_write_data(ds277Xg_config_t *config, uint8_t *data, uint16_t len);
 
 /**
  * \brief 

--- a/firmware/drivers/ds277Xg/ds277Xg.h
+++ b/firmware/drivers/ds277Xg/ds277Xg.h
@@ -58,12 +58,12 @@
  * @brief DS277XG IC parameters
  */
 #define DS277XG_RSENSE                                          0.01        /* Unit: Ohm. */
-#define DS277XG_RSENSE_MOHMS                                    10          /* Unit: milliohms. */
+#define DS277XG_RSENSE_MOHMS                                    10U         /* Unit: milliohms. */
 #define DS277XG_RSENSE_CONDUCTANCE                              100         /* Unit: Siemens. */
 #define DS277XG_CHARGE_VOLTAGE_REG_RESOLUTION                   0.0195      /* Unit: millivolts */
 #define DS277XG_MINIMUM_CHARGE_CURRENT_REG_RESOLUTION           50          /* Unit: microvolts */
 #define DS277XG_ACTIVE_EMPTY_VOLTAGE_REG_RESOLUTION             0.0195      /* Unit: Volts */
-#define DS277XG_ACTIVE_EMPTY_CURRENT_REG_RESOLUTION             200         /* Unit: microolts */
+#define DS277XG_ACTIVE_EMPTY_CURRENT_REG_RESOLUTION             200U        /* Unit: microolts */
 #define DS277XG_AGE_SCALAR_REG_RESOLUTION                       0.0078125   /* Unit: Dimentionless (percentage) */
 #define DS277XG_VOLTAGE_REG_RESOLUTION                          4.8828      /* Unit: millivolts */
 #define DS277XG_CURRENT_REG_RESOLUTION                          1.5625      /* Unit: microvolts */
@@ -71,7 +71,7 @@
 #define DS277XG_ACCUMULATED_CURRENT_REG_RESOLUTION              6.25        /* Unit: microvolts */
 #define DS277XG_FULL_40_REG_RESOLUTION                          6.25        /* Unit: microvolts */
 #define DS277XG_ACTIVE_EMPTY_40_REG_RESOLUTION                  976.5625    /* Unit: ppm */
-#define DS277XG_SEGMENT_SLOPE_REG_RESOLUTION                    61          /* Unit: ppm */
+#define DS277XG_SEGMENT_SLOPE_REG_RESOLUTION                    61U          /* Unit: ppm */
 
 /**
  * @brief Battery cell parameters
@@ -81,7 +81,7 @@
 #define CELL_MINIMUM_CHARGE_CURRENT                             (0.05 * MAX_BATTERY_CHARGE)     /* Unit: milliamperes */
 #define CELL_INITIAL_AGE_SCALAR                                 1                            /* Unit: Dimentionless (percentage) */
 #define CELL_ACTIVE_EMPTY_VOLTAGE                               2.75                            /* Unit: Volts */
-#define CELL_ACTIVE_EMPTY_CURRENT                               100                             /* Unit: miliamperes */
+#define CELL_ACTIVE_EMPTY_CURRENT                               100U                            /* Unit: miliamperes */
 #define CELL_FULL_40_CAPACITY                                   ((uint16_t)(2* MAX_BATTERY_CHARGE * DS277XG_RSENSE_MOHMS))
 #define CELL_ACTIVE_EMPTY_40_CAPACITY                           0U                               /* ppm of Full 40 capacity */
 #define CELL_FULL_SLOPE_4                                       0U                              /* Unit: ppm/C° */
@@ -108,10 +108,10 @@
 #define DS277XG_ACCUMULATION_BIAS_REG_VALUE                      0x00
 #define DS277XG_AGING_CAPACITY_REG_VALUE_MSB                     ((uint8_t)(((uint16_t)(MAX_BATTERY_CHARGE * DS277XG_RSENSE_MOHMS) >> 8) / DS277XG_ACCUMULATED_CURRENT_REG_RESOLUTION))
 #define DS277XG_AGING_CAPACITY_REG_VALUE_LSB                     ((uint8_t)((uint16_t)((MAX_BATTERY_CHARGE * DS277XG_RSENSE_MOHMS) / DS277XG_ACCUMULATED_CURRENT_REG_RESOLUTION)))
-#define DS277XG_CHARGE_VOLTAGE_REG_VALUE                         ((uint8_t)(CELL_FULLY_CHARGED_VOLTAGE / DS277XG_CHARGE_VOLTAGE_REG_RESOLUTION))
+#define DS277XG_CHARGE_VOLTAGE_REG_VALUE                         ((uint8_t)(((uint16_t)(CELL_FULLY_CHARGED_VOLTAGE * 10000)) / ((uint16_t)(DS277XG_CHARGE_VOLTAGE_REG_RESOLUTION * 10000)))) /* Casts to uint16_t and multiply by 10000 to satisfy misra C 2012 rules */
 #define DS277XG_MINIMUM_CHARGE_CURRENT_REG_VALUE                 ((uint8_t)((CELL_MINIMUM_CHARGE_CURRENT * DS277XG_RSENSE_MOHMS) / DS277XG_MINIMUM_CHARGE_CURRENT_REG_RESOLUTION))
-#define DS277XG_ACTIVE_EMPTY_VOLTAGE_REG_VALUE                   ((uint8_t)(CELL_ACTIVE_EMPTY_VOLTAGE / DS277XG_ACTIVE_EMPTY_VOLTAGE_REG_RESOLUTION))
-#define DS277XG_ACTIVE_EMPTY_CURRENT_REG_VALUE                   ((uint8_t)(CELL_ACTIVE_EMPTY_CURRENT*DS277XG_RSENSE_MOHMS / DS277XG_ACTIVE_EMPTY_CURRENT_REG_RESOLUTION))
+#define DS277XG_ACTIVE_EMPTY_VOLTAGE_REG_VALUE                   ((uint8_t)((uint16_t)(CELL_ACTIVE_EMPTY_VOLTAGE * 10000) / (uint16_t)(DS277XG_ACTIVE_EMPTY_VOLTAGE_REG_RESOLUTION * 10000)))
+#define DS277XG_ACTIVE_EMPTY_CURRENT_REG_VALUE                   ((uint8_t)(CELL_ACTIVE_EMPTY_CURRENT * DS277XG_RSENSE_MOHMS / DS277XG_ACTIVE_EMPTY_CURRENT_REG_RESOLUTION))
 #define DS277XG_ACTIVE_EMPTY_40_REG_VALUE                        ((uint8_t)(CELL_ACTIVE_EMPTY_40_CAPACITY / DS277XG_ACTIVE_EMPTY_40_REG_RESOLUTION))
 #define DS277XG_SENSE_RESISTOR_PRIME_REG_VALUE                   ((uint8_t)(DS277XG_RSENSE_CONDUCTANCE))
 #define DS277XG_FULL_40_MSB_REG_VALUE                            ((uint8_t)((uint16_t)((CELL_FULL_40_CAPACITY >> 8) / DS277XG_FULL_40_REG_RESOLUTION)))
@@ -139,12 +139,12 @@
 #define DS277XG_TWO_WIRE_SLAVE_ADDRESS_REG_VALUE                 (DS2777G_DEFAULT_SLAVE_ADDRESS << 1)
 
 #define DS277XG_PARAMETER_EEPROM_ADDRESS                         0x60
-#define DS277XG_PARAMETER_EEPROM_SIZE                            33
+#define DS277XG_PARAMETER_EEPROM_SIZE                            33U
 
 /**
  * \brief DS277XG Commands
  */
-#define DS2777G_DEFAULT_SLAVE_ADDRESS                           0b1011001
+#define DS2777G_DEFAULT_SLAVE_ADDRESS                           0b1011001u
 #define DS2775G_SKIP_ADDRESS                                    0xCC        //Address that access any onewire device (used when there's only one device at the onewire bus)
 #define DS2775G_WRITE_DATA                                      0x6C        //Command to write a data in the DS2775G+ memory
 #define DS2775G_READ_DATA                                       0x69        //Command to read a data from DS2775G+ memory
@@ -257,10 +257,10 @@
  * \brief Register specific bit mask.
  */
 // Protection register.
-#define DS277XG_CHARGE_CONTROL_FLAG                             (1 << 3)
-#define DS277XG_DISCHARGE_CONTROL_FLAG                          (1 << 2)
-#define DS277XG_CHARGE_ENABLE_BIT                               (1 << 1)
-#define DS277XG_DISCHARGE_ENABLE_BIT                            (1 << 0)
+#define DS277XG_CHARGE_CONTROL_FLAG                             (1U << 3U)
+#define DS277XG_DISCHARGE_CONTROL_FLAG                          (1U << 2U)
+#define DS277XG_CHARGE_ENABLE_BIT                               (1U << 1U)
+#define DS277XG_DISCHARGE_ENABLE_BIT                            (1U << 0U)
 
 typedef struct
 {

--- a/firmware/tests/devices/Makefile
+++ b/firmware/tests/devices/Makefile
@@ -19,7 +19,7 @@ CC=gcc
 INC=../../
 FLAGS=-fpic -std=c99 -Wall -pedantic -Wshadow -Wpointer-arith -Wcast-qual -Wstrict-prototypes -Wmissing-prototypes -I$(INC) -Wl,--wrap=sys_log_print_event_from_module,--wrap=sys_log_new_line,--wrap=sys_log_print_msg,--wrap=sys_log_print_uint,--wrap=sys_log_print_int,--wrap=sys_log_print_float,--wrap=adc_init,--wrap=adc_read,--wrap=adc_temp_get_mref,--wrap=adc_temp_get_nref,--wrap=gpio_init,--wrap=gpio_set_state,--wrap=gpio_get_state,--wrap=gpio_toggle,--wrap=wdt_init,--wrap=wdt_reset,--wrap=tps382x_init,--wrap=tps382x_trigger
 
-BATTERY_MONITOR_TEST_FLAGS=$(FLAGS),--wrap=ds277Xg_init,--wrap=ds277Xg_read_voltage_mv,--wrap=ds277Xg_read_temperature_kelvin,--wrap=ds277Xg_read_current_ma,--wrap=ds277Xg_read_data
+BATTERY_MONITOR_TEST_FLAGS=$(FLAGS),--wrap=ds277Xg_init,--wrap=ds277Xg_read_voltage_mv,--wrap=ds277Xg_read_temperature_kelvin,--wrap=ds277Xg_read_current_ma,--wrap=ds277Xg_read_data,--wrap=ds277Xg_read_accumulated_current_mah
 CURRENT_SENSOR_TEST_FLAGS=$(FLAGS),--wrap=adc_init,--wrap=adc_read,--wrap=adc_temp_get_mref,--wrap=adc_temp_get_nref,--wrap=adc_mutex_give,--wrap=adc_mutex_take,--wrap=max9934_read,--wrap=max9934_init
 HEATER_TEST_FLAGS=$(FLAGS),--wrap=pwm_init,--wrap=pwm_update,--wrap=pwm_stop,--wrap=pwm_disable,--wrap=temp_rtd_read_k,--wrap=temp_rtd_raw_to_k,--wrap=temp_rtd_read_raw
 MEDIA_TEST_FLAGS=$(FLAGS),--wrap=flash_init,--wrap=flash_write,--wrap=flash_write_single,--wrap=flash_read_single,--wrap=flash_write_long,--wrap=flash_read_long,--wrap=flash_erase

--- a/firmware/tests/devices/battery_monitor_test.c
+++ b/firmware/tests/devices/battery_monitor_test.c
@@ -24,8 +24,9 @@
  * \brief Unit test of the Battery Monitor device
  *
  * \author Lucas Zacchi de Medeiros <lucas.zacchi@spacelab.ufsc.br>
+ * \author Ramon de Araujo Borba <ramonborba07@gmail.com>
  *
- * \version 0.1.0
+ * \version 0.4.0
  *
  * \date 2022/07/12
  *
@@ -55,34 +56,6 @@ static void battery_monitor_init_test(void **state)
 {
     will_return(__wrap_ds277Xg_init, 0);
     assert_return_code(battery_monitor_init(), 0);
-}
-
-static void bm_get_cell_one_voltage_test(void **state)
-{
-    int16_t voltage = 0;
-
-    for (int16_t i = CELL_VOLTAGE_MIN; i <= CELL_VOLTAGE_MAX; ++i)
-    {
-        expect_value(__wrap_ds277Xg_read_voltage_mv, battery_select, 1);
-        will_return(__wrap_ds277Xg_read_voltage_mv, i);
-        will_return(__wrap_ds277Xg_read_voltage_mv, 0);
-        assert_return_code(bm_get_cell_one_voltage(&voltage), 0);
-        assert_int_equal(voltage, i);
-    }
-}
-
-static void bm_get_cell_two_voltage_test(void **state)
-{
-    int16_t voltage = 0;
-
-    for (int16_t i = CELL_VOLTAGE_MIN; i <= CELL_VOLTAGE_MAX; ++i)
-    {
-        expect_value(__wrap_ds277Xg_read_voltage_mv, battery_select, 2);
-        will_return(__wrap_ds277Xg_read_voltage_mv, i);
-        will_return(__wrap_ds277Xg_read_voltage_mv, 0);
-        assert_return_code(bm_get_cell_two_voltage(&voltage), 0);
-        assert_int_equal(voltage, i);
-    }
 }
 
 static void bm_get_voltage_test(void **state)
@@ -182,12 +155,38 @@ static void bm_get_rsrc_percent_test(void **state)
     assert_return_code(bm_get_rsrc_percent(&data), 0);
 }
 
+static void bm_get_acc_current_mah_test(void **state)
+{
+    uint16_t data = 0;
+    will_return(__wrap_ds277Xg_read_accumulated_current_mah, 0);
+    assert_return_code(bm_get_acc_current_mah(&data), 0);
+}
+
+static void bm_get_full_capacity_ppm_test(void **state)
+{
+    uint32_t data = 0;
+    will_return(__wrap_ds277Xg_read_data, 0);
+    assert_return_code(bm_get_full_capacity_ppm(&data), 0);
+}
+
+static void bm_get_active_empty_capacity_ppm_test(void **state)
+{
+    uint32_t data = 0;
+    will_return(__wrap_ds277Xg_read_data, 0);
+    assert_return_code(bm_get_active_empty_capacity_ppm(&data), 0);
+}
+
+static void bm_get_standby_empty_capacity_ppm_test(void **state)
+{
+    uint32_t data = 0;
+    will_return(__wrap_ds277Xg_read_data, 0);
+    assert_return_code(bm_get_standby_empty_capacity_ppm(&data), 0);
+}
+
 int main(void)
 {
     const struct CMUnitTest battery_monitor_tests[] = {
         cmocka_unit_test(battery_monitor_init_test),
-        cmocka_unit_test(bm_get_cell_one_voltage_test),
-        cmocka_unit_test(bm_get_cell_two_voltage_test),
         cmocka_unit_test(bm_get_voltage_test),
         cmocka_unit_test(bm_get_temperature_kelvin_test),
         cmocka_unit_test(bm_get_instantaneous_current_test),
@@ -198,6 +197,10 @@ int main(void)
         cmocka_unit_test(bm_get_rsac_mah_test),
         cmocka_unit_test(bm_get_rarc_percent_test),
         cmocka_unit_test(bm_get_rsrc_percent_test),
+        cmocka_unit_test(bm_get_acc_current_mah_test),
+        cmocka_unit_test(bm_get_full_capacity_ppm_test),
+        cmocka_unit_test(bm_get_active_empty_capacity_ppm_test),
+        cmocka_unit_test(bm_get_standby_empty_capacity_ppm_test),
     };
 
     return cmocka_run_group_tests(battery_monitor_tests, NULL, NULL);


### PR DESCRIPTION
Changes:
- Correctly configured the battery model on the ds277Xg device.
    - Added macros for the registers values.
    - Changed implementation of init function to account for all registers.
- Added functions to read full, active-empty and standby-empty capacity result registers.
- Removed unused macros and functions related to onewire.
- Refactored ds277Xg driver and battery_monitor device for MISRA-C2012 compliance.